### PR TITLE
fix: stuck InfiniteQuery due to race conditions

### DIFF
--- a/packages/cached_query/lib/src/cached_query.dart
+++ b/packages/cached_query/lib/src/cached_query.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:cached_query/cached_query.dart';
 import 'package:cached_query/src/util/encode_key.dart';
+import 'package:cached_query/src/util/future_extension.dart';
 import 'package:cached_query/src/util/list_extension.dart';
 import 'package:cached_query/src/util/page_equality.dart';
 import 'package:meta/meta.dart';

--- a/packages/cached_query/lib/src/infinite_query.dart
+++ b/packages/cached_query/lib/src/infinite_query.dart
@@ -136,7 +136,9 @@ class InfiniteQuery<T, Arg> extends QueryBase<List<T>, InfiniteQueryState<T>> {
   /// Get the next page in an [InfiniteQuery] and cache the result.
   Future<InfiniteQueryState<T>?> getNextPage() async {
     if (state.hasReachedMax) return null;
-    _currentFuture ??= _fetchNextPage();
+    if (_currentFuture == null || _currentFuture!.isCompleted()) {
+      _currentFuture = _fetchNextPage();
+    }
     await _currentFuture;
     return state;
   }
@@ -146,7 +148,9 @@ class InfiniteQuery<T, Arg> extends QueryBase<List<T>, InfiniteQueryState<T>> {
   /// Returns the updated [State] and will notify the [stream].
   @override
   Future<InfiniteQueryState<T>> refetch() async {
-    _currentFuture ??= _refetch();
+    if (_currentFuture == null || _currentFuture!.isCompleted()) {
+      _currentFuture = _refetch();
+    }
     await _currentFuture;
     return state;
   }

--- a/packages/cached_query/lib/src/util/future_extension.dart
+++ b/packages/cached_query/lib/src/util/future_extension.dart
@@ -1,0 +1,11 @@
+import 'dart:async';
+
+/// Extension on Future.
+extension FutureExtension<T> on Future<T> {
+  /// Checks weather this [Future] has returned a value, using a completer.
+  bool isCompleted() {
+    final completer = Completer<T>();
+    then(completer.complete).catchError(completer.completeError);
+    return completer.isCompleted;
+  }
+}


### PR DESCRIPTION
I changed
```dart
_currentFuture ??= _refetch();
```
to
```dart
if (_currentFuture == null || _currentFuture!.isCompleted()) {
  _currentFuture = _refetch();
}
```

Both in fetch() and getNextPage(). This should make the system more robust.