### PR TITLE
feat: listener and consumer widgets

### DIFF
--- a/packages/cached_query_flutter/lib/cached_query_flutter.dart
+++ b/packages/cached_query_flutter/lib/cached_query_flutter.dart
@@ -6,4 +6,8 @@ export 'src/cached_query_flutter.dart';
 export 'src/infinite_query_builder.dart';
 export 'src/query_config_flutter.dart';
 export 'src/mutation_builder.dart';
+export 'src/mutation_consumer.dart';
+export 'src/mutation_listener.dart';
 export 'src/query_builder.dart';
+export 'src/query_consumer.dart';
+export 'src/query_listener.dart';

--- a/packages/cached_query_flutter/lib/src/mutation_consumer.dart
+++ b/packages/cached_query_flutter/lib/src/mutation_consumer.dart
@@ -1,0 +1,50 @@
+import 'package:cached_query/cached_query.dart';
+import 'package:flutter/material.dart';
+
+import 'mutation_builder.dart';
+import 'mutation_listener.dart';
+
+/// {@template mutationListener}
+/// Combination of [MutationBuilder] and [MutationListener] which allows listening to specific mutation changes
+/// and also rebuilds on mutation changes.
+/// {@endtemplate}
+class MutationConsumer<T, A> extends StatelessWidget {
+  /// The [Mutation] to used to update the listener.
+  final Mutation<T, A> mutation;
+
+  /// {@macro mutationListenerCallback}
+  final MutationListenerCallback<T> listener;
+
+  /// {@macro mutationListenerCondition}
+  final MutationListenerCondition<T>? listenWhen;
+
+  /// {@macro mutationBuilder}
+  final MutationBuilderCallback<T, A> builder;
+
+  /// {@macro mutationBuilderCondition}
+  final MutationBuilderCondition<T>? buildWhen;
+
+  /// {@macro MutationConsumer}
+  const MutationConsumer({
+    Key? key,
+    required this.mutation,
+    required this.listener,
+    this.listenWhen,
+    required this.builder,
+    this.buildWhen,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MutationListener(
+      mutation: mutation,
+      listener: listener,
+      listenWhen: listenWhen,
+      child: MutationBuilder(
+        mutation: mutation,
+        buildWhen: buildWhen,
+        builder: builder,
+      ),
+    );
+  }
+}

--- a/packages/cached_query_flutter/lib/src/mutation_listener.dart
+++ b/packages/cached_query_flutter/lib/src/mutation_listener.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:cached_query/cached_query.dart';
+import 'package:flutter/material.dart';
+
+/// {@template mutationListenerCallback}
+/// Called on each state change.
+///
+/// Passes [MutationState].
+/// {@endtemplate}
+typedef MutationListenerCallback<T> = void Function(MutationState<T> state);
+
+/// {@template mutationListenerCondition}
+/// This function is being called every time the mutation registered in the [MutationListener] receives new updates
+/// and let's you control when the [MutationListenerCallback] should be called
+/// {@endtemplate}
+typedef MutationListenerCondition<T> = FutureOr<bool> Function(
+  MutationState<T> oldState,
+  MutationState<T> newState,
+);
+
+/// {@template mutationListener}
+/// Listen to changes in an [Mutation] and call the listener with the result.
+/// {@endtemplate}
+class MutationListener<T, A> extends StatefulWidget {
+  /// The [Mutation] to used to update the listener.
+  final Mutation<T, A> mutation;
+
+  /// {@macro mutationListenerCallback}
+  final MutationListenerCallback<T> listener;
+
+  /// {@macro mutationListenerCondition}
+  final MutationListenerCondition<T>? listenWhen;
+
+  /// The child widget to render
+  final Widget child;
+
+  /// {@macro mutationListener}
+  const MutationListener({
+    Key? key,
+    required this.mutation,
+    required this.listener,
+    this.listenWhen,
+    required this.child,
+  }) : super(key: key);
+
+  @override
+  State<MutationListener<T, A>> createState() => _MutationListenerState<T, A>();
+}
+
+class _MutationListenerState<T, A> extends State<MutationListener<T, A>> {
+  late MutationState<T> _previousState;
+  late StreamSubscription<MutationState<T>> _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _previousState = widget.mutation.state;
+    _subscription = widget.mutation.stream.listen((state) async {
+      final listenWhen = widget.listenWhen;
+      if (listenWhen != null) {
+        final shouldListen =
+            await Future.value(listenWhen(_previousState, state));
+        if (!shouldListen) return;
+      }
+      widget.listener(state);
+      _previousState = state;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+}

--- a/packages/cached_query_flutter/lib/src/query_consumer.dart
+++ b/packages/cached_query_flutter/lib/src/query_consumer.dart
@@ -1,0 +1,50 @@
+import 'package:cached_query/cached_query.dart';
+import 'package:flutter/material.dart';
+
+import 'query_builder.dart';
+import 'query_listener.dart';
+
+/// {@template queryListener}
+/// Combination of [QueryBuilder] and [QueryListener] which allows listening to specific query changes
+/// and also rebuilds on query changes.
+/// {@endtemplate}
+class QueryConsumer<T> extends StatelessWidget {
+  /// The [Query] to used to update the listener.
+  final Query<T> query;
+
+  /// {@macro queryListenerCallback}
+  final QueryListenerCallback<T> listener;
+
+  /// {@macro queryListenerCondition}
+  final QueryListenerCondition<T>? listenWhen;
+
+  /// {@macro queryBuilder}
+  final QueryBuilderCallback<T> builder;
+
+  /// {@macro queryBuilderCondition}
+  final QueryBuilderCondition<T>? buildWhen;
+
+  /// {@macro QueryConsumer}
+  const QueryConsumer({
+    Key? key,
+    required this.query,
+    required this.listener,
+    this.listenWhen,
+    required this.builder,
+    this.buildWhen,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return QueryListener(
+      query: query,
+      listener: listener,
+      listenWhen: listenWhen,
+      child: QueryBuilder(
+        query: query,
+        buildWhen: buildWhen,
+        builder: builder,
+      ),
+    );
+  }
+}

--- a/packages/cached_query_flutter/test/matchers/is_query_state.dart
+++ b/packages/cached_query_flutter/test/matchers/is_query_state.dart
@@ -1,0 +1,58 @@
+import 'package:cached_query/cached_query.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+QueryStateMatcher<T> isQueryState<T>({
+  QueryStatus? status,
+  T? data,
+  Object? error,
+}) =>
+    QueryStateMatcher<T>(
+      status: status,
+      data: data,
+      error: error,
+    );
+
+class QueryStateMatcher<T> extends TypeMatcher<QueryState<T>> {
+  final QueryStatus? _status;
+  final T? _data;
+  final Object? _error;
+
+  QueryStateMatcher({QueryStatus? status, T? data, Object? error})
+      : _status = status,
+        _data = data,
+        _error = error;
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) =>
+      super.matches(item, matchState) &&
+      typedMatches(item as QueryState<T>, matchState);
+
+  bool typedMatches(QueryState<T> item, Map<dynamic, dynamic> matchState) {
+    var matches = true;
+    if (_status != null && _status != item.status) {
+      matches = false;
+    }
+    if (_data != null && _data != item.data) {
+      matches = false;
+    }
+    if (_error != null && _error != item.error) {
+      matches = false;
+    }
+    return matches;
+  }
+
+  @override
+  Description describe(Description description) {
+    final parts = <String>[];
+    if (_status != null) {
+      parts.add('status: $_status');
+    }
+    if (_data != null) {
+      parts.add('data: $_data');
+    }
+    if (_error != null) {
+      parts.add('error: $_error');
+    }
+    return description.add('matches QueryState<$T>(${parts.join(', ')})');
+  }
+}

--- a/packages/cached_query_flutter/test/query_listener_test.dart
+++ b/packages/cached_query_flutter/test/query_listener_test.dart
@@ -1,0 +1,87 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'matchers/is_query_state.dart';
+import 'repo/query_repo.dart';
+import 'utils/expect_query_states.dart';
+
+void main() {
+  group("Query listener", () {
+    setUp(CachedQuery.instance.deleteCache);
+
+    testWidgets(
+      "Builds widget with supplied child and calls listener",
+      (tester) async {
+        const response = "My Title";
+        const child = Text('Hello world');
+        final sink = expectQueryStates<String>([
+          isQueryState(status: QueryStatus.loading),
+          isQueryState(status: QueryStatus.success, data: response),
+        ]);
+        await tester.pumpWidget(
+          MaterialApp(
+            home: QueryListener(
+              query: const TitleRepo(response: response).fetchTitle(),
+              listener: sink.add,
+              child: child,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final childFinder = find.byWidget(child);
+        expect(childFinder, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      "Does not call listener for loading state if listenWhen is supplied",
+      (tester) async {
+        const response = "My Title";
+        const child = Text('Hello world');
+        final sink = expectQueryStates<String>([
+          isQueryState(status: QueryStatus.success, data: response),
+        ]);
+        await tester.pumpWidget(
+          MaterialApp(
+            home: QueryListener(
+              query: const TitleRepo(response: response).fetchTitle(),
+              listenWhen: (oldState, newState) =>
+                  newState.status == QueryStatus.success,
+              listener: sink.add,
+              child: child,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final childFinder = find.byWidget(child);
+        expect(childFinder, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      "Query is build from key",
+      (tester) async {
+        const response = "My Title";
+        const child = Text('Hello world');
+        final sink = expectQueryStates<String>([
+          isQueryState(status: QueryStatus.loading),
+          isQueryState(status: QueryStatus.success, data: response),
+        ]);
+        const TitleRepo(response: response).fetchTitle();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: QueryListener(
+              queryKey: TitleRepo.key,
+              listener: sink.add,
+              child: child,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final childFinder = find.byWidget(child);
+        expect(childFinder, findsOneWidget);
+      },
+    );
+  });
+}

--- a/packages/cached_query_flutter/test/repo/query_repo.dart
+++ b/packages/cached_query_flutter/test/repo/query_repo.dart
@@ -15,4 +15,11 @@ class TitleRepo {
       config: QueryConfig(ignoreCacheDuration: true),
     );
   }
+
+  Mutation<String, String> updateTitle() {
+    return Mutation(
+      queryFn: (title) =>
+          Future.delayed(queryDelay ?? Duration.zero, () => title),
+    );
+  }
 }

--- a/packages/cached_query_flutter/test/utils/expect_query_states.dart
+++ b/packages/cached_query_flutter/test/utils/expect_query_states.dart
@@ -1,0 +1,14 @@
+import 'dart:async';
+
+import 'package:cached_query/cached_query.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../matchers/is_query_state.dart';
+
+Sink<QueryState<T>> expectQueryStates<T>(
+  Iterable<QueryStateMatcher<T>> matchers,
+) {
+  final controller = StreamController<QueryState<T>>();
+  expect(controller.stream, emitsInOrder(matchers));
+  return controller.sink;
+}


### PR DESCRIPTION
The currently existing widgets are useful to update the ui when query/mutation states change. However it can be useful to react to side effects from the build method as well so I've implemented listener and consumer widgets to support this. The implementation is inspired by the way Bloc library implements this: https://pub.dev/documentation/flutter_bloc/latest/index.html