### PR TITLE
feat: add enabled flag to disable queries

### DIFF
--- a/examples/full/pubspec.lock
+++ b/examples/full/pubspec.lock
@@ -111,21 +111,21 @@ packages:
       path: "../../packages/cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   cached_query_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/cached_query_flutter"
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   cached_storage:
     dependency: "direct main"
     description:
       path: "../../packages/cached_storage"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   characters:
     dependency: transitive
     description:

--- a/examples/full_with_bloc/pubspec.lock
+++ b/examples/full_with_bloc/pubspec.lock
@@ -127,14 +127,14 @@ packages:
       path: "../../packages/cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   cached_query_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/cached_query_flutter"
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:

--- a/examples/infinite_list/pubspec.lock
+++ b/examples/infinite_list/pubspec.lock
@@ -111,21 +111,21 @@ packages:
       path: "../../packages/cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   cached_query_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/cached_query_flutter"
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   cached_storage:
     dependency: "direct main"
     description:
       path: "../../packages/cached_storage"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   characters:
     dependency: transitive
     description:

--- a/examples/infinite_list_with_bloc/pubspec.lock
+++ b/examples/infinite_list_with_bloc/pubspec.lock
@@ -47,14 +47,14 @@ packages:
       path: "../../packages/cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   cached_query_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/cached_query_flutter"
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:

--- a/examples/mutation/pubspec.lock
+++ b/examples/mutation/pubspec.lock
@@ -31,14 +31,14 @@ packages:
       path: "../../packages/cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   cached_query_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/cached_query_flutter"
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:

--- a/examples/simple_caching/pubspec.lock
+++ b/examples/simple_caching/pubspec.lock
@@ -31,14 +31,14 @@ packages:
       path: "../../packages/cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   cached_query_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/cached_query_flutter"
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:

--- a/examples/simple_caching_with_bloc/pubspec.lock
+++ b/examples/simple_caching_with_bloc/pubspec.lock
@@ -47,14 +47,14 @@ packages:
       path: "../../packages/cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   cached_query_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/cached_query_flutter"
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:

--- a/packages/cached_query/lib/src/cached_query.dart
+++ b/packages/cached_query/lib/src/cached_query.dart
@@ -271,6 +271,7 @@ class CachedQuery {
     if (filterFn != null) {
       final queries = _filterQueryKey(filter: filterFn);
       for (final query in queries) {
+        if (!query.config.enabled) continue;
         query.refetch();
       }
     }
@@ -278,6 +279,7 @@ class CachedQuery {
       for (final key in keys) {
         final k = encodeKey(key);
         if (_queryCache.containsKey(k)) {
+          if (!_queryCache[k]!.config.enabled) continue;
           _queryCache[k]!.refetch();
         }
       }

--- a/packages/cached_query/lib/src/infinite_query.dart
+++ b/packages/cached_query/lib/src/infinite_query.dart
@@ -125,6 +125,10 @@ class InfiniteQuery<T, Arg> extends QueryBase<List<T>, InfiniteQueryState<T>> {
         config: config,
       );
       globalCache.addQuery(query);
+    } else {
+      query.config = query.config.copyWith(
+        enabled: config?.enabled,
+      );
     }
 
     if (prefetchPages != null) {
@@ -173,6 +177,9 @@ class InfiniteQuery<T, Arg> extends QueryBase<List<T>, InfiniteQueryState<T>> {
 
   @override
   Future<InfiniteQueryState<T>> _getResult({bool forceRefetch = false}) async {
+    if (!config.enabled) {
+      return _state;
+    }
     final hasData = _state.data != null && _state.data!.isNotEmpty;
     if (!stale &&
         !forceRefetch &&

--- a/packages/cached_query/lib/src/infinite_query.dart
+++ b/packages/cached_query/lib/src/infinite_query.dart
@@ -177,14 +177,12 @@ class InfiniteQuery<T, Arg> extends QueryBase<List<T>, InfiniteQueryState<T>> {
 
   @override
   Future<InfiniteQueryState<T>> _getResult({bool forceRefetch = false}) async {
-    if (!config.enabled) {
-      return _state;
-    }
     final hasData = _state.data != null && _state.data!.isNotEmpty;
-    if (!stale &&
-        !forceRefetch &&
-        _state.status != QueryStatus.error &&
-        hasData) {
+    if ((!config.enabled && !forceRefetch) ||
+        (!stale &&
+            !forceRefetch &&
+            _state.status != QueryStatus.error &&
+            hasData)) {
       _emit();
       return _state;
     }

--- a/packages/cached_query/lib/src/query.dart
+++ b/packages/cached_query/lib/src/query.dart
@@ -80,6 +80,10 @@ class Query<T> extends QueryBase<T, QueryState<T>> {
         config: config,
       );
       globalCache.addQuery(query);
+    } else {
+      query.config = query.config.copyWith(
+        enabled: config?.enabled,
+      );
     }
 
     return query;
@@ -104,6 +108,9 @@ class Query<T> extends QueryBase<T, QueryState<T>> {
 
   @override
   Future<QueryState<T>> _getResult({bool forceRefetch = false}) async {
+    if (!config.enabled) {
+      return _state;
+    }
     if (!stale &&
         !forceRefetch &&
         _state.status != QueryStatus.error &&

--- a/packages/cached_query/lib/src/query.dart
+++ b/packages/cached_query/lib/src/query.dart
@@ -108,13 +108,11 @@ class Query<T> extends QueryBase<T, QueryState<T>> {
 
   @override
   Future<QueryState<T>> _getResult({bool forceRefetch = false}) async {
-    if (!config.enabled) {
-      return _state;
-    }
-    if (!stale &&
-        !forceRefetch &&
-        _state.status != QueryStatus.error &&
-        _state.data != null) {
+    if ((!config.enabled && !forceRefetch) ||
+        (!stale &&
+            !forceRefetch &&
+            _state.status != QueryStatus.error &&
+            _state.data != null)) {
       _emit();
       return _state;
     }

--- a/packages/cached_query/lib/src/query_base.dart
+++ b/packages/cached_query/lib/src/query_base.dart
@@ -56,7 +56,7 @@ abstract class QueryBase<T, State extends QueryState<dynamic>> {
   }
 
   /// The config for this specific query.
-  final QueryConfig config;
+  QueryConfig config;
 
   /// Weather the query stream has any listeners.
   bool get hasListener => _streamController?.hasListener ?? false;

--- a/packages/cached_query/lib/src/query_config.dart
+++ b/packages/cached_query/lib/src/query_config.dart
@@ -82,6 +82,13 @@ class QueryConfig {
   ///{@macro QueryConfig.ShouldRefetch}
   final ShouldRefetch? shouldRefetch;
 
+  /// {@template QueryConfig.enabled}
+  /// If set to true the queryFn will not run.
+  ///
+  /// Defaults to true;
+  /// {@endtemplate}
+  final bool enabled;
+
   const QueryConfig._({
     required this.shouldRefetch,
     required this.serializer,
@@ -93,6 +100,7 @@ class QueryConfig {
     required this.refetchDuration,
     required this.cacheDuration,
     required this.shouldRethrow,
+    required this.enabled,
   });
 
   /// Returns a query config with the default values.
@@ -107,6 +115,7 @@ class QueryConfig {
         refetchDuration: Duration(seconds: 4),
         cacheDuration: Duration(minutes: 5),
         shouldRethrow: false,
+        enabled: true,
       );
 
   /// {@macro queryConfig}
@@ -139,6 +148,7 @@ class QueryConfig {
     Duration? refetchDuration,
     Duration? cacheDuration,
     bool? shouldRethrow,
+    bool? enabled,
     // use the defaults if not set
   })  : serializer =
             serializer ?? CachedQuery.instance.defaultConfig.serializer,
@@ -159,7 +169,8 @@ class QueryConfig {
         shouldRefetch =
             shouldRefetch ?? CachedQuery.instance.defaultConfig.shouldRefetch,
         shouldRethrow =
-            shouldRethrow ?? CachedQuery.instance.defaultConfig.shouldRethrow;
+            shouldRethrow ?? CachedQuery.instance.defaultConfig.shouldRethrow,
+        enabled = enabled ?? CachedQuery.instance.defaultConfig.enabled;
 
   @override
   bool operator ==(Object other) =>
@@ -173,7 +184,8 @@ class QueryConfig {
           serializer == other.serializer &&
           storageDeserializer == other.storageDeserializer &&
           storageSerializer == other.storageSerializer &&
-          ignoreCacheDuration == other.ignoreCacheDuration;
+          ignoreCacheDuration == other.ignoreCacheDuration &&
+          enabled == other.enabled;
 
   @override
   int get hashCode =>
@@ -183,5 +195,37 @@ class QueryConfig {
       shouldRethrow.hashCode ^
       serializer.hashCode ^
       storageDeserializer.hashCode ^
-      ignoreCacheDuration.hashCode;
+      ignoreCacheDuration.hashCode ^
+      enabled.hashCode;
+
+  /// Returns a copy of the current [QueryConfig] with the provided values.
+  ///
+  /// If a value is not provided the current value is used.
+  QueryConfig copyWith({
+    bool? enabled,
+    Duration? cacheDuration,
+    bool? ignoreCacheDuration,
+    Duration? refetchDuration,
+    bool? shouldRethrow,
+    Serializer? serializer,
+    Serializer? storageDeserializer,
+    Serializer? storageSerializer,
+    bool? storeQuery,
+    ShouldRefetch? shouldRefetch,
+    Duration? storageDuration,
+  }) {
+    return QueryConfig(
+      enabled: enabled ?? this.enabled,
+      cacheDuration: cacheDuration ?? this.cacheDuration,
+      ignoreCacheDuration: ignoreCacheDuration ?? this.ignoreCacheDuration,
+      refetchDuration: refetchDuration ?? this.refetchDuration,
+      shouldRethrow: shouldRethrow ?? this.shouldRethrow,
+      serializer: serializer ?? this.serializer,
+      storageDeserializer: storageDeserializer ?? this.storageDeserializer,
+      storageSerializer: storageSerializer ?? this.storageSerializer,
+      storeQuery: storeQuery ?? this.storeQuery,
+      shouldRefetch: shouldRefetch ?? this.shouldRefetch,
+      storageDuration: storageDuration ?? this.storageDuration,
+    );
+  }
 }

--- a/packages/cached_query/test/cached_query_test.dart
+++ b/packages/cached_query/test/cached_query_test.dart
@@ -239,12 +239,16 @@ void main() {
       final query = MockQuery<String>();
       final query2 = MockInfiniteQuery<int, String>();
       final query3 = MockQuery<String>();
+
       when(query.key).thenReturn("query");
       when(query.unencodedKey).thenReturn("query");
+      when(query.config).thenReturn(QueryConfig.defaults());
       when(query2.key).thenReturn("query2");
       when(query2.unencodedKey).thenReturn("query2");
+      when(query2.config).thenReturn(QueryConfig.defaults());
       when(query3.key).thenReturn("other_key");
       when(query3.unencodedKey).thenReturn("other_key");
+      when(query3.config).thenReturn(QueryConfig.defaults());
 
       when(query.refetch()).thenAnswer(
         (_) async => QueryState(timeCreated: DateTime.now()),
@@ -280,11 +284,13 @@ void main() {
     test("Refetch queries", () {
       final query = MockQuery<String>();
       when(query.key).thenReturn("query");
+      when(query.config).thenReturn(QueryConfig.defaults());
       when(query.refetch()).thenAnswer(
         (_) async => QueryState(timeCreated: DateTime.now()),
       );
       final query2 = MockQuery<String>();
       when(query2.key).thenReturn("query2");
+      when(query2.config).thenReturn(QueryConfig.defaults());
 
       when(query2.refetch()).thenAnswer(
         (_) async => QueryState(timeCreated: DateTime.now()),

--- a/packages/cached_query/test/infinite_query_test.dart
+++ b/packages/cached_query/test/infinite_query_test.dart
@@ -821,4 +821,62 @@ void main() async {
       expect(numCalls, 2);
     });
   });
+
+  group("Enable", () {
+    test("should never fetch if enabled is false", () async {
+      int numCalls = 0;
+      final query = InfiniteQuery(
+        key: "enabled_false",
+        getNextArg: (state) => 1,
+        queryFn: (_) {
+          numCalls++;
+          return Future.value(1);
+        },
+        config: QueryConfig(enabled: false),
+      );
+      await query.result;
+      expect(numCalls, 0);
+    });
+
+    test("should fetch if enabled is true", () async {
+      int numCalls = 0;
+      final query = InfiniteQuery(
+        key: "enabled_true",
+        getNextArg: (state) => 1,
+        queryFn: (_) {
+          numCalls++;
+          return Future.value(1);
+        },
+        config: QueryConfig(enabled: true),
+      );
+      await query.result;
+      expect(numCalls, 1);
+    });
+
+    test("should fetch query after change enabled to true", () async {
+      int numCalls = 0;
+      var query = InfiniteQuery(
+        key: "toggle_enabled",
+        getNextArg: (state) => 1,
+        queryFn: (_) {
+          numCalls++;
+          return Future.value(1);
+        },
+        config: QueryConfig(enabled: false),
+      );
+      await query.result;
+      expect(numCalls, 0);
+      query = InfiniteQuery(
+        key: "toggle_enabled",
+        getNextArg: (state) => 1,
+        queryFn: (_) {
+          numCalls++;
+          return Future.value(1);
+        },
+        config: QueryConfig(enabled: true),
+      );
+      await query.result;
+      expect(numCalls, 1);
+    });
+  });
 }

--- a/packages/cached_query/test/infinite_query_test.dart
+++ b/packages/cached_query/test/infinite_query_test.dart
@@ -879,7 +879,8 @@ void main() async {
       expect(numCalls, 1);
     });
 
-    test("should refetch even if the enabled flag is false", () async {
+    test("should refetch using query.refetch even if the enabled flag is false",
+        () async {
       int numCalls = 0;
       final query = InfiniteQuery(
         key: "query_refetch_enabled_false",

--- a/packages/cached_query/test/infinite_query_test.dart
+++ b/packages/cached_query/test/infinite_query_test.dart
@@ -878,5 +878,40 @@ void main() async {
       await query.result;
       expect(numCalls, 1);
     });
+
+    test("should refetch even if the enabled flag is false", () async {
+      int numCalls = 0;
+      final query = InfiniteQuery(
+        key: "query_refetch_enabled_false",
+        getNextArg: (state) => 1,
+        queryFn: (_) {
+          numCalls++;
+          return Future.value(1);
+        },
+        config: QueryConfig(enabled: false),
+      );
+      expect(numCalls, 0);
+      await query.refetch();
+      expect(numCalls, 1);
+    });
+
+    test(
+        "should not refetch using CachedQuery.refetchQueries if the enabled flag is false ",
+        () async {
+      int numCalls = 0;
+      InfiniteQuery(
+        key: "cached_query_refetch_enabled_false",
+        getNextArg: (state) => 1,
+        queryFn: (_) {
+          numCalls++;
+          return Future.value(1);
+        },
+        config: QueryConfig(enabled: false),
+      );
+      expect(numCalls, 0);
+      CachedQuery.instance
+          .refetchQueries(keys: ["cached_query_refetch_enabled_false"]);
+      expect(numCalls, 0);
+    });
   });
 }

--- a/packages/cached_query/test/mutation_test.dart
+++ b/packages/cached_query/test/mutation_test.dart
@@ -184,6 +184,7 @@ void main() {
       const key = "refetch";
       final query = MockQuery<String>();
       when(query.key).thenReturn(key);
+      when(query.config).thenReturn(QueryConfig.defaults());
       CachedQuery.instance.addQuery(query);
       final mutation = Mutation<String, void>(
         refetchQueries: [key],

--- a/packages/cached_query/test/query_test.dart
+++ b/packages/cached_query/test/query_test.dart
@@ -604,5 +604,39 @@ void main() {
       await query.result;
       expect(numCalls, 1);
     });
+
+    test("should refetch using query.refetch even if the enabled flag is false",
+        () async {
+      int numCalls = 0;
+      final query = Query(
+        key: "refetch_enabled_false",
+        queryFn: () {
+          numCalls++;
+          return Future.value("");
+        },
+        config: QueryConfig(enabled: false),
+      );
+      expect(numCalls, 0);
+      await query.refetch();
+      expect(numCalls, 1);
+    });
+
+    test(
+        "should not refetch using CachedQuery.refetchQueries if the enabled flag is false ",
+        () async {
+      int numCalls = 0;
+      Query(
+        key: "cached_query_refetch_enabled_false",
+        queryFn: () {
+          numCalls++;
+          return Future.value("");
+        },
+        config: QueryConfig(enabled: false),
+      );
+      expect(numCalls, 0);
+      CachedQuery.instance
+          .refetchQueries(keys: ["cached_query_refetch_enabled_false"]);
+      expect(numCalls, 0);
+    });
   });
 }

--- a/packages/cached_query/test/query_test.dart
+++ b/packages/cached_query/test/query_test.dart
@@ -551,4 +551,58 @@ void main() {
       expect(numCalls, 2);
     });
   });
+
+  group("Enable", () {
+    test("should never fetch if enabled is false", () async {
+      int numCalls = 0;
+      final query = Query(
+        key: "enabled_false",
+        queryFn: () {
+          numCalls++;
+          return Future.value("");
+        },
+        config: QueryConfig(enabled: false),
+      );
+      await query.result;
+      expect(numCalls, 0);
+    });
+
+    test("should fetch if enabled is true", () async {
+      int numCalls = 0;
+      final query = Query(
+        key: "enabled_true",
+        queryFn: () {
+          numCalls++;
+          return Future.value("");
+        },
+        config: QueryConfig(enabled: true),
+      );
+      await query.result;
+      expect(numCalls, 1);
+    });
+
+    test("should fetch query after change enabled to true", () async {
+      int numCalls = 0;
+      var query = Query(
+        key: "toggle_enabled",
+        queryFn: () {
+          numCalls++;
+          return Future.value("");
+        },
+        config: QueryConfig(enabled: false),
+      );
+      await query.result;
+      expect(numCalls, 0);
+      query = Query(
+        key: "toggle_enabled",
+        queryFn: () {
+          numCalls++;
+          return Future.value("");
+        },
+        config: QueryConfig(enabled: true),
+      );
+      await query.result;
+      expect(numCalls, 1);
+    });
+  });
 }

--- a/packages/cached_query_flutter/example/pubspec.lock
+++ b/packages/cached_query_flutter/example/pubspec.lock
@@ -31,14 +31,14 @@ packages:
       path: "../../cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   cached_query_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:

--- a/packages/devtools_extension/pubspec.lock
+++ b/packages/devtools_extension/pubspec.lock
@@ -119,7 +119,7 @@ packages:
       path: "../cached_query"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.5"
   characters:
     dependency: transitive
     description:


### PR DESCRIPTION
The purpose is to replicate the behavior of the [enabled](https://tanstack.com/query/v4/docs/framework/react/guides/disabling-queries) flag from Tanstack Query.

I needed to create the `QueryConfig.copyWith` function to keep the constructor constant, and I also needed to create a public setter for `Query.config` to update the enabled flag. I'm not sure if this is the best approach, so I'm open to suggestions.