### PR TITLE
feat: added background duration to fetchOnResume

### DIFF
--- a/packages/cached_query_flutter/lib/src/query_config_flutter.dart
+++ b/packages/cached_query_flutter/lib/src/query_config_flutter.dart
@@ -5,15 +5,33 @@ import 'package:cached_query/cached_query.dart';
 /// {@endtemplate}
 class QueryConfigFlutter extends QueryConfig {
   /// Whether this query should be re-fetched when the app comes into the foreground
-  final bool? refetchOnResume;
+  /// 
+  /// Defaults to true.
+  final bool refetchOnResume;
+
+  /// How long the app needs to stay in the background before refetching the
+  /// query if [refetchOnResume] is true.
+  /// 
+  /// Defaults to 5 seconds.
+  /// 
+  /// Note: 
+  /// Some Android devices with missconfigured settings appear to trigger
+  /// forground and background events in quick succession while beeing
+  /// constantly in the foreground. 
+  /// Having a value greater than 500ms will prevent those devices from
+  /// refetching the query on these kinds of sketchy events.
+  final Duration refetchOnResumeMinBackgroundDuration;
 
   /// Whether this query should be re-fetched when the device gains connection
-  final bool? refetchOnConnection;
+  /// 
+  /// Defaults to true.
+  final bool refetchOnConnection;
 
   /// {@macro queryConfigFlutter}
   QueryConfigFlutter({
-    this.refetchOnResume,
-    this.refetchOnConnection,
+    this.refetchOnResume = true,
+    this.refetchOnResumeMinBackgroundDuration = const Duration(seconds: 5),
+    this.refetchOnConnection = true,
     @Deprecated('Use QueryConfig.storageDeserializer instead')
     Serializer? serializer,
     Serializer? storageSerializer,
@@ -38,4 +56,19 @@ class QueryConfigFlutter extends QueryConfig {
           cacheDuration: cacheDuration,
           shouldRethrow: shouldRethrow,
         );
+
+  
+  /// Returns a flutter query config with the default values.
+  static final QueryConfigFlutter defaults = QueryConfigFlutter(
+    // Note: leaving out non optional parameters, as they get their defaults
+    // inside the constructor.
+    storageSerializer: QueryConfig.defaults().storageSerializer,
+    storageDeserializer: QueryConfig.defaults().storageDeserializer,
+    storageDuration: QueryConfig.defaults().storageDuration,
+    ignoreCacheDuration: QueryConfig.defaults().ignoreCacheDuration,
+    storeQuery: QueryConfig.defaults().storeQuery,
+    refetchDuration: QueryConfig.defaults().refetchDuration,
+    cacheDuration: QueryConfig.defaults().cacheDuration,
+    shouldRethrow: QueryConfig.defaults().shouldRethrow,
+  );
 }

--- a/packages/cached_query_flutter/pubspec.yaml
+++ b/packages/cached_query_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_query_flutter
 description: Assortment of builders and addons for use with Cached Query in flutter.
-version: 2.3.0
+version: 2.3.1
 repository: https://github.com/D-James-GH/cached_query/tree/main/packages/cached_query_flutter
 documentation: https://cachedquery.dev/
 homepage: https://cachedquery.dev/


### PR DESCRIPTION
Hi there,

this is a relative small improvement but has a big impact on some devices. This pull requests adds a new attribute to the QueryConfigFlutter namely the `refetchOnResumeMinBackgroundDuration`.

I noticed a strange behavior on a small fraction of Android devices. Some of them seem to be missconfigured by the users or OS distributors that causes weird background / foreground behavior. Some devices fire the enter background / enter foreground events rapidly often times more than 3 times a second - even tho the app stays in foreground all the time.

There is defenitly something wrong with the Android devices BUT as a developer I do not care what people do with their phones. 
What we do care about is that this library which helps us destress our servers in some cases master stress our servers. 
5% of users are currently the source of 95% of the server traffic. If you think about it it makes sence. Every time the app resume event is fired (3 times a second) our server gets hit by all their active queries.

I changed little but introducing the min background duration after which a resume event is actually beeing treated as a resume event. I had to introduce `QueryConfigFlutter.defaults` as well in order to configure this behavior with a non flutter config. By doing this I was allowed to remove the `_getResumeDefaults()` and `_getConnectionDefaults()` methods.

These is an excerpt from the property I added:
```dart
  /// How long the app needs to stay in the background before refetching the
  /// query if [refetchOnResume] is true.
  /// 
  /// Defaults to 5 seconds.
  /// 
  /// Note: 
  /// Some Android devices with missconfigured settings appear to trigger
  /// forground and background events in quick succession while beeing
  /// constantly in the foreground. 
  /// Having a value greater than 500ms will prevent those devices from
  /// refetching the query on these kinds of sketchy events.
  final Duration refetchOnResumeMinBackgroundDuration;
```