### PR TITLE
fix: manual query update > local storage & web platform check

### DIFF
--- a/packages/cached_query/lib/src/infinite_query.dart
+++ b/packages/cached_query/lib/src/infinite_query.dart
@@ -163,6 +163,10 @@ class InfiniteQuery<T, Arg> extends QueryBase<List<T>, InfiniteQueryState<T>> {
       lastPage: _state.lastPage,
     );
     _setState(newState);
+    if (config.storeQuery) {
+      // save to local storage if exists
+      _saveToStorage();
+    }
     _emit();
   }
 

--- a/packages/cached_query/lib/src/query.dart
+++ b/packages/cached_query/lib/src/query.dart
@@ -110,6 +110,10 @@ class Query<T> extends QueryBase<T, QueryState<T>> {
     );
 
     _setState(newState);
+    if (config.storeQuery) {
+      // save to local storage if exists
+      _saveToStorage();
+    }
     _emit();
   }
 

--- a/packages/cached_query_flutter/lib/src/cached_query_flutter.dart
+++ b/packages/cached_query_flutter/lib/src/cached_query_flutter.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:cached_query_flutter/cached_query_flutter.dart';
 import 'package:cached_query_flutter/src/connectivity_controller.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// The reason the cache is being refetched.
@@ -105,7 +106,7 @@ class _LifecycleObserver extends WidgetsBindingObserver {
 
   bool shouldNotify() {
     if (_lastPaused == null) {
-      if (Platform.isIOS || Platform.isAndroid) {
+      if (!kIsWeb && (Platform.isIOS || Platform.isAndroid)) {
         return false;
       }
       // Note: Other platforms might never enter full background mode so we


### PR DESCRIPTION
Hi James 👋🏻 hope your doing well.

I noticed a tiny error in the framework (arguably its a feature but I think you did not intend it to be this way).

If a manual update of a query is performed, it is not stored in the local storage. This leads to some issue I noticed in our current app.

We have a list of games query + a single game request query. If the games list query gets fetched we also manually update the single game query for that item if existent. That works perfectly fine but after the user exits the app and reopens it he sees the old game state because the single query got only updated in memory not on local storage.

I assume that this is not the intended behavior because there is literally no way of manually triggering the storage process.

I went through the regular fetch process of the query and copied the code for storage into the update method - I also looked for references of the update method and I am pretty sure that this change has 0 side effects.

The only thing I am not sure about is the fact that I applied no try catch around the storage process. Maybe you know better if that is actually a good idea to catch errors in that location. (Maybe not catch but emit new state before storage process? I don't know).

The changes in the update methods are just 2 lines.

I also fixed a small thing I forget in my last pull request - I used `Platform.isAndroid` calls before excluding the possibility of a web build. Because web does not contain the Platform classes / apis (In my view a big flaw of flutter) you need to check that it is no web build before accessing those apis. Thats what I also added in this PR

Have a great day!

