### PR TITLE
Applies shouldRefetch config to refetchCurrentQueries

### DIFF
--- a/packages/cached_query_flutter/lib/src/cached_query_flutter.dart
+++ b/packages/cached_query_flutter/lib/src/cached_query_flutter.dart
@@ -67,19 +67,26 @@ extension CachedQueryExt on CachedQuery {
     for (final query in queries) {
       bool shouldRefetch = false;
       final config = query.config;
+
+      // Allow normal refetch rules if user has not configured shouldRefetch
+      final bool configShouldRefetch =
+          query.config.shouldRefetch?.call(query, false) ?? true;
+
       if (reason == null) {
-        shouldRefetch = true;
+        shouldRefetch = configShouldRefetch;
       } else if (reason == RefetchReason.resume) {
         if (config is QueryConfigFlutter) {
-          shouldRefetch = config.refetchOnResume;
+          shouldRefetch = config.refetchOnResume && configShouldRefetch;
         } else {
-          shouldRefetch = QueryConfigFlutter.defaults.refetchOnResume;
+          shouldRefetch = QueryConfigFlutter.defaults.refetchOnResume &&
+              configShouldRefetch;
         }
       } else if (reason == RefetchReason.connectivity) {
         if (config is QueryConfigFlutter) {
-          shouldRefetch = config.refetchOnConnection;
+          shouldRefetch = config.refetchOnConnection && configShouldRefetch;
         } else {
-          shouldRefetch = QueryConfigFlutter.defaults.refetchOnConnection;
+          shouldRefetch = QueryConfigFlutter.defaults.refetchOnConnection &&
+              configShouldRefetch;
         }
       }
 

--- a/packages/cached_query_flutter/test/cached_query_flutter_test.dart
+++ b/packages/cached_query_flutter/test/cached_query_flutter_test.dart
@@ -122,7 +122,9 @@ void main() {
 
       verifyNever(query.refetch());
     });
-    test("Can prevent refetchOnResume and refetchOnConnection using shouldRefetch", () async {
+    test(
+        "Can prevent refetchOnResume and refetchOnConnection using shouldRefetch",
+        () async {
       final query = MockQuery<String>();
       when(query.config).thenReturn(
         QueryConfigFlutter(

--- a/packages/cached_query_flutter/test/cached_query_flutter_test.dart
+++ b/packages/cached_query_flutter/test/cached_query_flutter_test.dart
@@ -122,6 +122,25 @@ void main() {
 
       verifyNever(query.refetch());
     });
+    test("Can prevent refetchOnResume and refetchOnConnection using shouldRefetch", () async {
+      final query = MockQuery<String>();
+      when(query.config).thenReturn(
+        QueryConfigFlutter(
+          shouldRefetch: (query, fromStorage) => false,
+        ),
+      );
+      when(query.hasListener).thenReturn(true);
+      when(query.key).thenReturn("hasListeners");
+      when(query.refetch()).thenAnswer((realInvocation) async {
+        return QueryState(timeCreated: DateTime.now(), data: "");
+      });
+      CachedQuery.asNewInstance()
+        ..addQuery(query)
+        ..refetchCurrentQueries(RefetchReason.resume)
+        ..refetchCurrentQueries(RefetchReason.connectivity);
+
+      verifyNever(query.refetch());
+    });
     test("Can override global config", () {
       CachedQuery.instance.configFlutter(
         config: QueryConfigFlutter(refetchOnResume: false),


### PR DESCRIPTION
This PR addresses issue #63 by applying a query's `shouldRefetch` config to `refetchCurrentQueries()`. This means that `refetchOnResume` and `refetchOnConnection` will now respect the query's `shouldRefetch` configuration.

