### PR TITLE
storeQuery default value inconsistent between code and documentation

### DIFF
--- a/packages/cached_query/lib/src/query_config.dart
+++ b/packages/cached_query/lib/src/query_config.dart
@@ -32,7 +32,7 @@ class GlobalQueryConfig {
 
   /// {@template QueryConfig.storeQuery}
   /// Use [storeQuery] to set whether a query should be stored or not.
-  /// Defaults to true;
+  /// Defaults to false;
   ///
   /// Only effective when [CachedQuery] storage is set.
   /// {@endtemplate}


### PR DESCRIPTION
This pull request updates the documentation for the `storeQuery` property in the `GlobalQueryConfig` class to reflect a change in its default value.

- Documentation update:
  * The docstring for the `storeQuery` property now states that it defaults to `false` instead of `true`, ensuring the documentation matches the actual default behavior.