### PR TITLE
fix: cached_query - replace refetchDuration with staleDuration on documentation

### DIFF
--- a/packages/cached_query/README.md
+++ b/packages/cached_query/README.md
@@ -86,14 +86,14 @@ void main() async {
   CachedQuery.instance.config(
     storage: await CachedStorage.ensureInitialized(),
     config: GlobalQueryConfig(
-      refetchDuration: Duration(seconds: 4),
+      staleDuration: Duration(seconds: 4),
       cacheDuration: Duration(minutes: 5),
     ),
   );
 }
 ```
 
-The QueryConfig can be overridden on any individual query. The `refetchDuration` sets the minimum time before the queryFn
+The QueryConfig can be overridden on any individual query. The `staleDuration` sets the minimum time before the queryFn
 is called again. The defaults to 4 seconds but if you know data is unlikely to get stale this could be increased. If you
 are using the `Query.stream` api then the latest current cached data will always be emitted while waiting for data to be returned
 from the queryFn.
@@ -104,10 +104,10 @@ the `Stream` api then the `cacheDuration` timer will start when the last listene
 
 ## Re-fetching and Invalidation
 
-Any Query will automatically be re-fetched if another call to the query function happens after the refetchDuration.
+Any Query will automatically be re-fetched if another call to the query function happens after the staleDuration.
 A Query can be forced to re-fetched at anytime using `Query.refetch()`.
 
-After the `refetchDuration` is finished the query will be marked as stale. This is what causes a refetch the next time
+After the `staleDuration` is finished the query will be marked as stale. This is what causes a refetch the next time
 the query is requested. A query can be manually be invalidated with `Query.invalidate()` or a list of queries can be
 invalidated at once with `CachedQuery.instance.invalidateCache`, this is useful during [Mutations](#mutation).
 

--- a/packages/cached_query/lib/src/cached_query.dart
+++ b/packages/cached_query/lib/src/cached_query.dart
@@ -75,7 +75,7 @@ class CachedQuery {
   /// Use [cacheDuration] to specify how long a query that has zero listeners
   /// stays in memory. Defaults to 5 minutes.
   ///
-  /// Use [refetchDuration] to specify how long before the query is re-fetched
+  /// Use [staleDuration] to specify how long before the query is re-fetched
   /// in the background. Defaults to 4 seconds
   ///
   /// Pass a [StorageInterface] to automatically store queries for fast initial

--- a/packages/cached_query/lib/src/query/infinite_query.dart
+++ b/packages/cached_query/lib/src/query/infinite_query.dart
@@ -19,7 +19,7 @@ typedef GetNextArg<T, Arg> = Arg? Function(InfiniteQueryData<T, Arg>? state);
 /// The [key] can be any serializable data. The [key] is converted to a [String]
 /// using [jsonEncode].
 ///
-/// Each [InfiniteQuery] can override the global defaults for [refetchDuration]
+/// Each [InfiniteQuery] can override the global defaults for [staleDuration]
 /// and [cacheDuration], see [CachedQuery.config] for more info.
 ///
 /// Use [revalidateAll] to sequentially refetch all cached pages if the first two

--- a/packages/cached_query/lib/src/query/query.dart
+++ b/packages/cached_query/lib/src/query/query.dart
@@ -53,7 +53,7 @@ Query<T> createEmptyQuery<T>({
 /// can be any serializable data. The [key] is converted to a [String] using
 /// [jsonEncode].
 ///
-/// Each [Query] can override the global defaults for [refetchDuration], [cacheDuration],
+/// Each [Query] can override the global defaults for [staleDuration], [cacheDuration],
 /// see [CachedQuery.config] for more info.
 ///
 /// Use [forceRefetch] to force the query to be run again regardless of whether

--- a/packages/cached_query/lib/src/query_config.dart
+++ b/packages/cached_query/lib/src/query_config.dart
@@ -247,7 +247,7 @@ class QueryConfig<Data> implements ControllerOptions<Data> {
   ///
   /// {@macro QueryConfig.storeQuery}
   ///
-  /// {@macro QueryConfig.refetchDuration}
+  /// {@macro QueryConfig.staleDuration}
   ///
   /// {@macro QueryConfig.cacheDuration}
   ///

--- a/packages/cached_query/test/infinite_query_test.dart
+++ b/packages/cached_query/test/infinite_query_test.dart
@@ -185,7 +185,7 @@ void main() async {
       });
       expect(res1, res2);
     });
-    test("Adding refetchDuration means next result will come from cache.",
+    test("Adding staleDuration means next result will come from cache.",
         () async {
       final cache = CachedQuery.asNewInstance();
       int fetchCount = 0;
@@ -339,7 +339,7 @@ void main() async {
     });
   });
   group("Infinite re-fetching", () {
-    test("Should refetch list after refetchDuration", () async {
+    test("Should refetch list after staleDuration", () async {
       final cache = CachedQuery.asNewInstance();
       int fetchCount = 0;
       final query = InfiniteQuery<String, int>(


### PR DESCRIPTION
On this Pull Request, I did address documentation part only, where a deprecated solution was proposed.


 **Changes**

- I did replace the mentioning of `refetchDuration` with `staleDuration`.