### PR TITLE
Fix: Ensure Latest State Is Available During Error Callbacks

### DIFF
--- a/packages/cached_query/CHANGELOG.md
+++ b/packages/cached_query/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.3
+
+- **FIX**: update query state before notifying observers to prevent stale state during onError.
+
 ## 3.3.2
 
  - **FIX**: devtools not working on 3.2.0+. ([7fa8e984](https://github.com/D-James-GH/cached_query/commit/7fa8e984629530a2925153b7a255a307eed01470))


### PR DESCRIPTION
This PR fixes an issue where **cache observers and error handlers were receiving `Query` and `Mutation` instances with stale state** when errors occurred.

As a result, consumers can not reliably access the associated `QueryError` / `MutationError`, including the `error` object.

---

## ❗ Problem

Both `Query` and `Mutation` previously:

* Maintained a duplicated internal `_state` field
* Updated that state **after** notifying observers
* Exposed stale state inside `onError` / `onMutationError`

---

## ✅ Solution

This PR removes duplicated internal state and makes the underlying `BehaviorSubject` the **single source of truth** for both `Query` and `Mutation`.

### What changed

* **Removed internal `_state` fields**
* **State is updated before observers are notified**
* **`state` always reflects the latest emitted value**
* **Error state is guaranteed to be available during callbacks**
* **Streams and observers now see identical state**

### Example (Query)

```dart
void _setState(QueryStatus<T> state, {required bool notifyObservers}) {
  // Update state first
  _stateSubject.add(state);

  if (notifyObservers) {
    for (final observer in _controller._cache.observers) {
      observer.onChange(this, state);

      if (state case QueryError(:final stackTrace)) {
        observer.onError(this, stackTrace);
      }
    }
  }
}
```

### Example (Mutation)

```dart
void _setState(MutationState<ReturnType> newState) {
  // Update state first
  _streamController.add(newState);

  for (final ob in CachedQuery.instance.observers) {
    ob.onMutationChange(this, newState);
  }

  if (state case MutationError(:final stackTrace)) {
    for (final ob in CachedQuery.instance.observers) {
      ob.onMutationError(this, stackTrace);
    }
  }
}
```

---

## 🔄 Behavior Changes

### Query & Mutation

| Behavior                         | Before          | After            |
| -------------------------------- | --------------- | ---------------- |
| Error callbacks see latest state | ❌ No            | ✅ Yes            |
| Access to error + stackTrace     | ❌ Unreliable    | ✅ Guaranteed     |
| State source                     | ❌ Duplicated    | ✅ Single source  |
| Observer notification order      | ❌ Before update | ✅ After update   |
| Stream & observer consistency    | ❌ Could desync  | ✅ Always in sync |