### PR TITLE
fix: allow to invalidate not yet cached keys

### DIFF
--- a/packages/cached_query/lib/src/cached_query.dart
+++ b/packages/cached_query/lib/src/cached_query.dart
@@ -221,6 +221,8 @@ class CachedQuery {
       final k = encodeKey(key);
       if (_queryCache.containsKey(k)) {
         queries = [_queryCache.get(k)!];
+      } else {
+        queries = [];
       }
     } else {
       // invalidate the whole cache


### PR DESCRIPTION
I encountered some LateInitialization errors while invalidating keys in the cache which did not exist. In case the key does not exist, the list of queries to invalidate should be initialized regardless to avoid these errors.